### PR TITLE
🛂 (clinet): Add JWT token in header for using authenticated router

### DIFF
--- a/apps/client/common/apollo.ts
+++ b/apps/client/common/apollo.ts
@@ -1,0 +1,23 @@
+import { ApolloClient, ApolloProvider, DefaultOptions, HttpLink, InMemoryCache, makeVar } from '@apollo/client';
+import { useMemo } from 'react';
+import { serverHost } from './link';
+
+function createApolloCLient() {
+  return new ApolloClient({
+    link: new HttpLink({
+      uri: serverHost.graphqlUrl,
+      credentials: 'same-origin',
+    }),
+    cache: new InMemoryCache(),
+    defaultOptions: {
+      watchQuery: {
+        fetchPolicy: 'cache-and-network',
+      },
+    },
+  });
+}
+
+export function useApollo() {
+  const client = useMemo(() => createApolloCLient(), []);
+  return client;
+}

--- a/apps/client/common/apollo.ts
+++ b/apps/client/common/apollo.ts
@@ -1,21 +1,10 @@
-import {
-  ApolloClient,
-  ApolloProvider,
-  createHttpLink,
-  DefaultOptions,
-  HttpLink,
-  InMemoryCache,
-  makeVar,
-} from '@apollo/client';
+import { ApolloClient, createHttpLink, InMemoryCache } from '@apollo/client';
 import { setContext } from '@apollo/client/link/context';
 import { useMemo } from 'react';
 import { loadAuthToken } from './auth/auth';
-import { useAuth } from './auth/useAuth';
 import { serverHost } from './link';
 
-function createApolloCLient(authToken: string | null) {
-  console.log('TCL: createApolloCLient -> authToken', authToken);
-
+function createApolloClient() {
   const httpLink = createHttpLink({
     uri: serverHost.graphqlUrl,
     credentials: 'same-origin',
@@ -25,8 +14,6 @@ function createApolloCLient(authToken: string | null) {
     const baseHeaders = { ...headers };
 
     const token = loadAuthToken();
-    console.log('TCL: authLink -> token', token);
-
     if (token) {
       baseHeaders.authorization = `Bearer ${token}`;
     }
@@ -39,7 +26,6 @@ function createApolloCLient(authToken: string | null) {
   });
 
   return new ApolloClient({
-    // link: new HttpLink({}),
     link: authLink.concat(httpLink),
     cache: new InMemoryCache(),
     defaultOptions: {
@@ -51,8 +37,7 @@ function createApolloCLient(authToken: string | null) {
 }
 
 export function useApollo() {
-  const { authToken } = useAuth();
-  const client = useMemo(() => createApolloCLient(authToken), [authToken]);
+  const client = useMemo(() => createApolloClient(), []);
 
   return client;
 }

--- a/apps/client/common/auth/useAuth.tsx
+++ b/apps/client/common/auth/useAuth.tsx
@@ -9,6 +9,7 @@ interface IAuthContext {
   logout: () => void;
   authenticated: boolean;
   setAuthenticated: (value: boolean) => void;
+  authToken: string | null;
 }
 
 const AuthContext = createContext<IAuthContext>({
@@ -16,11 +17,13 @@ const AuthContext = createContext<IAuthContext>({
   logout: () => null,
   authenticated: false,
   setAuthenticated: () => null,
+  authToken: null,
 });
 
 export const AuthProvider: FunctionComponent = ({ children }) => {
   const [user, setUser] = useState<User | null>(null);
   const [authenticated, setAuthenticated] = useState<boolean>(false);
+  const [authToken, setAuthToken] = useState<string | null>(null);
 
   const router = useRouter();
 
@@ -30,6 +33,7 @@ export const AuthProvider: FunctionComponent = ({ children }) => {
   const logoutFn = () => {
     clearAuthToken();
     setAuthenticated(false);
+    setAuthToken(null);
     router.push('/');
   };
 
@@ -42,6 +46,7 @@ export const AuthProvider: FunctionComponent = ({ children }) => {
     const token = loadAuthToken();
     if (token) {
       setAuthenticated(true);
+      setAuthToken(token);
     }
 
     // if (token) setIsLoggedIn(true);
@@ -49,7 +54,13 @@ export const AuthProvider: FunctionComponent = ({ children }) => {
 
   return (
     <AuthContext.Provider
-      value={{ user: null, logout: logoutFn, authenticated: authenticated, setAuthenticated: setAuthenticated }}
+      value={{
+        user: null,
+        logout: logoutFn,
+        authenticated: authenticated,
+        setAuthenticated: setAuthenticated,
+        authToken: authToken,
+      }}
     >
       {children}
     </AuthContext.Provider>

--- a/apps/client/common/auth/useAuth.tsx
+++ b/apps/client/common/auth/useAuth.tsx
@@ -27,9 +27,6 @@ export const AuthProvider: FunctionComponent = ({ children }) => {
 
   const router = useRouter();
 
-  // const viewModel = useMeViewModel();
-  // console.log('TCL: AuthProvider:FunctionComponent -> viewModel', viewModel);
-
   const logoutFn = () => {
     clearAuthToken();
     setAuthenticated(false);
@@ -37,19 +34,12 @@ export const AuthProvider: FunctionComponent = ({ children }) => {
     router.push('/');
   };
 
-  // const setAuthenticated = (value: boolean) => {
-
-  // }
-
-  // TODO(Teddy): Auth
   useEffect(() => {
     const token = loadAuthToken();
     if (token) {
       setAuthenticated(true);
       setAuthToken(token);
     }
-
-    // if (token) setIsLoggedIn(true);
   }, []);
 
   return (

--- a/apps/client/components/modules/HomeComp/HomeComp.tsx
+++ b/apps/client/components/modules/HomeComp/HomeComp.tsx
@@ -1,0 +1,9 @@
+import { useMeViewModel } from '@readable/common/auth/useAuth.query';
+import React from 'react';
+import { MeViewController } from '../Me/MeViewController';
+
+export function HomeComp() {
+  const viewModel = useMeViewModel();
+
+  return <MeViewController viewModel={viewModel} />;
+}

--- a/apps/client/components/modules/HomeComp/index.ts
+++ b/apps/client/components/modules/HomeComp/index.ts
@@ -1,0 +1,1 @@
+export * from './HomeComp';

--- a/apps/client/components/modules/Me/MeViewController.tsx
+++ b/apps/client/components/modules/Me/MeViewController.tsx
@@ -5,7 +5,6 @@ import React from 'react';
 
 export const MeViewController: ViewController<MeViewModel> = React.memo(({ viewModel }) => {
   const { me, loading, error } = viewModel;
-
   const { authenticated } = useAuth();
 
   if (loading) {
@@ -17,25 +16,22 @@ export const MeViewController: ViewController<MeViewModel> = React.memo(({ viewM
   }
 
   if (error) {
-    return <>{error.message}</>;
+    return <div className="h-screen flex justify-center items-center text-2xl">Please login.</div>;
   }
 
-  const { _id, provider, providerId, name, avatarUrl } = me;
+  const { provider, name, avatarUrl } = me;
 
   return (
-    <div>
+    <div className="h-screen flex justify-center items-center text-2xl">
       {authenticated ? (
-        <div className="h-screen flex justify-center items-center text-2xl">
-          <ul>
-            <li>
-              Welcome {name} from {provider}, back !!!
-            </li>
-            {/* <li>{provider}</li> */}
-            <img src={avatarUrl} alt="avatar" />
-          </ul>
-        </div>
+        <ul>
+          <li>
+            Welcome {name} from {provider}, back !!!
+          </li>
+          <img src={avatarUrl} alt="avatar" />
+        </ul>
       ) : (
-        'Plase login.'
+        'Please login.'
       )}
     </div>
   );

--- a/apps/client/components/modules/Me/MeViewController.tsx
+++ b/apps/client/components/modules/Me/MeViewController.tsx
@@ -1,0 +1,42 @@
+import { useAuth } from '@readable/common/auth/useAuth';
+import { MeViewModel } from '@readable/common/auth/useAuth.query';
+import { ViewController } from '@readable/types/ViewController';
+import React from 'react';
+
+export const MeViewController: ViewController<MeViewModel> = React.memo(({ viewModel }) => {
+  const { me, loading, error } = viewModel;
+
+  const { authenticated } = useAuth();
+
+  if (loading) {
+    return (
+      <div className="h-screen flex justify-center items-center">
+        <span className="font-medium text-xl tracking-wide">Loading...</span>
+      </div>
+    );
+  }
+
+  if (error) {
+    return <>{error.message}</>;
+  }
+
+  const { _id, provider, providerId, name, avatarUrl } = me;
+
+  return (
+    <div>
+      {authenticated ? (
+        <div className="h-screen flex justify-center items-center text-2xl">
+          <ul>
+            <li>
+              Welcome {name} from {provider}, back !!!
+            </li>
+            {/* <li>{provider}</li> */}
+            <img src={avatarUrl} alt="avatar" />
+          </ul>
+        </div>
+      ) : (
+        'Plase login.'
+      )}
+    </div>
+  );
+});

--- a/apps/client/components/modules/Me/useMeViewModel.query.generated.tsx
+++ b/apps/client/components/modules/Me/useMeViewModel.query.generated.tsx
@@ -1,0 +1,64 @@
+import * as Types from '../../../types/graphql-types';
+
+import { gql } from '@apollo/client';
+import * as React from 'react';
+import * as Apollo from '@apollo/client';
+import * as ApolloReactComponents from '@apollo/client/react/components';
+export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+const defaultOptions =  {}
+export type MeQueryQueryVariables = Types.Exact<{ [key: string]: never; }>;
+
+
+export type MeQueryQuery = (
+  { readonly __typename?: 'Query' }
+  & { readonly me: (
+    { readonly __typename?: 'User' }
+    & Pick<Types.User, '_id' | 'name' | 'provider' | 'providerId' | 'avatarUrl'>
+  ) }
+);
+
+
+export const MeQueryDocument = gql`
+    query MeQuery {
+  me: me {
+    _id
+    name
+    provider
+    providerId
+    avatarUrl
+  }
+}
+    `;
+export type MeQueryComponentProps = Omit<ApolloReactComponents.QueryComponentOptions<MeQueryQuery, MeQueryQueryVariables>, 'query'>;
+
+    export const MeQueryComponent = (props: MeQueryComponentProps) => (
+      <ApolloReactComponents.Query<MeQueryQuery, MeQueryQueryVariables> query={MeQueryDocument} {...props} />
+    );
+    
+
+/**
+ * __useMeQueryQuery__
+ *
+ * To run a query within a React component, call `useMeQueryQuery` and pass it any options that fit your needs.
+ * When your component renders, `useMeQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useMeQueryQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useMeQueryQuery(baseOptions?: Apollo.QueryHookOptions<MeQueryQuery, MeQueryQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<MeQueryQuery, MeQueryQueryVariables>(MeQueryDocument, options);
+      }
+export function useMeQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<MeQueryQuery, MeQueryQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<MeQueryQuery, MeQueryQueryVariables>(MeQueryDocument, options);
+        }
+export type MeQueryQueryHookResult = ReturnType<typeof useMeQueryQuery>;
+export type MeQueryLazyQueryHookResult = ReturnType<typeof useMeQueryLazyQuery>;
+export type MeQueryQueryResult = Apollo.QueryResult<MeQueryQuery, MeQueryQueryVariables>;

--- a/apps/client/components/modules/Me/useMeViewModel.query.tsx
+++ b/apps/client/components/modules/Me/useMeViewModel.query.tsx
@@ -1,0 +1,29 @@
+import { gql } from '@apollo/client';
+import { ViewModel } from '@readable/types/ViewModel';
+import { useMeQueryQuery } from './useMeViewModel.query.generated';
+
+const ME_QUERY = gql`
+  query MeQuery {
+    me: me {
+      _id
+      name
+      provider
+      providerId
+      avatarUrl
+    }
+  }
+`;
+
+export type MeViewModel = ViewModel<typeof useMeViewModel>;
+
+export function useMeViewModel() {
+  const { data, loading, error } = useMeQueryQuery();
+
+  const me = data?.me ?? null;
+
+  return {
+    me,
+    loading,
+    error,
+  };
+}

--- a/apps/client/lib/withApollo.tsx
+++ b/apps/client/lib/withApollo.tsx
@@ -3,6 +3,10 @@ import { useRouter } from 'next/router';
 import nextWithApollo from 'next-with-apollo';
 import { serverHost } from '@readable/common/link';
 
+/**
+ * deprecate
+ */
+
 const withApollo = nextWithApollo(
   ({ initialState, headers }) => {
     return new ApolloClient({

--- a/apps/client/pages/_app.tsx
+++ b/apps/client/pages/_app.tsx
@@ -4,15 +4,21 @@ import 'tailwindcss/tailwind.css';
 import '@readable/styles/styles.css';
 import '@readable/styles/style.scss';
 import { AuthProvider } from '@readable/common/auth/useAuth';
+import { useApollo } from '@readable/common/apollo';
+import { ApolloProvider } from '@apollo/client';
 
 function CustomApp({ Component, pageProps }: AppProps) {
+  const client = useApollo();
+
   return (
     <AuthProvider>
-      <Head>
-        <title>Readable</title>
-        <link rel="icon" href="/images/favicon.ico" />
-      </Head>
-      <Component {...pageProps} />
+      <ApolloProvider client={client}>
+        <Head>
+          <title>Readable</title>
+          <link rel="icon" href="/images/favicon.ico" />
+        </Head>
+        <Component {...pageProps} />
+      </ApolloProvider>
     </AuthProvider>
   );
 }

--- a/apps/client/pages/index.tsx
+++ b/apps/client/pages/index.tsx
@@ -2,9 +2,10 @@ import { Layout } from '@readable/components/layout';
 import withApollo from '@readable/lib/withApollo';
 import React from 'react';
 import { getDataFromTree } from '@apollo/client/react/ssr';
+import { HomeComp } from '@readable/components/modules/HomeComp';
 
 function Home() {
-  return <Layout main={<>Home</>} />;
+  return <Layout main={<HomeComp />} />;
 }
 
 export default Home;

--- a/apps/client/pages/index.tsx
+++ b/apps/client/pages/index.tsx
@@ -7,5 +7,5 @@ function Home() {
   return <Layout main={<>Home</>} />;
 }
 
-// export default Home;
-export default withApollo(Home, { getDataFromTree });
+export default Home;
+// export default withApollo(Home, { getDataFromTree });


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

* Login 하여 얻은 JWT token 을 `Authorization: Bearer {token}` 헤더에 보내서 authenticated router 이용할 수 있음.
* 예제로 `/` 페이지에서 `/me` query 하여 유저 정보 얻어와서 표시하도록 함.

![Xnip2021-07-18_09-16-01](https://user-images.githubusercontent.com/365500/126052036-b0be82ab-0ead-4aff-8d48-c0e40b678779.jpg)


## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] ✨ New feature (non-breaking change which adds new functionality)
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ♻️ Refactor (non-breaking change which refactors code)
- [ ] 🩹 Chore (non-breaking change which changes the small things)
- [ ] 📝 This change requires a documentation update

## Further to-do lists

<!-- If there are something to do further, please share them. -->
