### PR TITLE
🛂 (server): Get Google refereshToken after login for Google Calendar API usage

### DIFF
--- a/apps/server/src/auth/domain/strategies/google.strategy.ts
+++ b/apps/server/src/auth/domain/strategies/google.strategy.ts
@@ -14,11 +14,20 @@ export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
       clientID: process.env.OAUTH_GOOGLE_CLIENT_ID,
       clientSecret: process.env.OAUTH_GOOGLE_CLIENT_PW,
       callbackURL: process.env.OAUTH_GOOGLE_CALLBACK_URL,
-      scope: ['email', 'profile'],
-      accessType: 'offline',
-      prompt: 'consent',
+      scope: [
+        'email',
+        'profile',
+        // 'https://www.googleapis.com/auth/calendar',
+      ],
     });
   }
+
+  // MEMO(Teddy): for getting refresh token
+  // https://stackoverflow.com/a/64217203/2453632
+  authorizationParams(): { [key: string]: string } {
+    return { access_type: 'offline', prompt: 'consent' };
+  }
+
   async validate(accessToken: string, refreshToken: string, profile: any, done: VerifyCallback): Promise<any> {
     const googleUser = new SigninInput();
     googleUser.name = profile?.displayName ?? `${profile?.name?.givenName}${profile?.name?.familyName}`;


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Google OAuth login 시에 `accessToken` 과 함께 `refereshToken` 얻기.

* 해당 app 연동 시 최초 한 번 만 가능.
    - `access_type = offline`
    - `prompt = consent`

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ✨ New feature (non-breaking change which adds new functionality)
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [X] ♻️ Refactor (non-breaking change which refactors code)
- [ ] 🩹 Chore (non-breaking change which changes the small things)
- [ ] 📝 This change requires a documentation update

## Further to-do lists

<!-- If there are something to do further, please share them. -->
