### PR TITLE
♻️ (server,client): Refactor pagination query parameter format for apollo cache update

### DIFF
--- a/apps/server/src/common/pagination/paginationCursor.input.ts
+++ b/apps/server/src/common/pagination/paginationCursor.input.ts
@@ -1,0 +1,20 @@
+import { Field, InputType } from '@nestjs/graphql';
+import { PaginationOrder, PaginationOrderBy } from './paginationCursor';
+
+@InputType()
+export class PaginationCursorInput {
+  @Field(type => PaginationOrderBy)
+  orderBy: PaginationOrderBy;
+
+  @Field(type => PaginationOrderBy)
+  order: PaginationOrder;
+
+  @Field(type => Date)
+  createdAt: Date;
+
+  constructor(orderBy: PaginationOrderBy, order: PaginationOrder, createdAt: Date) {
+    this.orderBy = orderBy;
+    this.order = order;
+    this.createdAt = createdAt;
+  }
+}

--- a/apps/server/src/common/pagination/paginationCursor.ts
+++ b/apps/server/src/common/pagination/paginationCursor.ts
@@ -1,4 +1,4 @@
-import { registerEnumType } from '@nestjs/graphql';
+import { ObjectType, InputType, registerEnumType } from '@nestjs/graphql';
 import { PaginationFromCursorFailException } from '../error';
 
 export enum PaginationOrderBy {
@@ -21,6 +21,7 @@ registerEnumType(PaginationOrder, {
   description: 'Pagination Order (ASC or DESC)',
 });
 
+@ObjectType()
 export class PaginationCursor {
   orderBy: PaginationOrderBy;
 

--- a/apps/server/src/graphql-types.gql
+++ b/apps/server/src/graphql-types.gql
@@ -80,17 +80,6 @@ input DeleteBookmarkWithAuthInput {
   bookmarkId: String!
 }
 
-input GetPaginationBookmarksInput {
-  after: PaginationCursor
-  first: Int = 10
-
-  """Pagination bookmarks order field"""
-  order: PaginationOrder = DESC
-
-  """Pagination bookmarks orderBy field"""
-  orderBy: PaginationOrderBy = LATEST
-}
-
 type Mutation {
   addBookmarkInGoogleEventsWithAuth(addInGoogleEventsInput: AddInGoogleEventsInput!): CommonOutput!
   addBookmarkWithAuth(addBookMarkWithAuthInput: AddBookMarkWithAuthInput!): Bookmark!
@@ -150,7 +139,7 @@ type PaginationPageInfo {
 type Query {
   me: User!
   myBookmarks: [Bookmark!]!
-  paginationBookmarks(getPaginationBookmarksInput: GetPaginationBookmarksInput!): PaginationBookmarks
+  paginationBookmarks(after: PaginationCursor, first: Int = 10, order: PaginationOrder = DESC, orderBy: PaginationOrderBy = LATEST): PaginationBookmarks
 }
 
 type User {

--- a/apps/server/src/pagination/paginationBookmarks/applications/usecases/get-pagination-bookmarks/get-pagination-bookmarks.usecase.ts
+++ b/apps/server/src/pagination/paginationBookmarks/applications/usecases/get-pagination-bookmarks/get-pagination-bookmarks.usecase.ts
@@ -10,7 +10,6 @@ export class GetPaginationBookmarksUsecase
   constructor(@InjectRepository(BookmarksRepository) private readonly bookmarksRepository: BookmarksRepository) {}
 
   async execute(query: GetPaginationBookmarksInput, requestUser: User) {
-    console.log('TCL: execute -> query', query);
     return this.bookmarksRepository.getPaginationBookmarks(query, requestUser);
   }
 }

--- a/apps/server/src/pagination/paginationBookmarks/paginationBookmarks.resolver.ts
+++ b/apps/server/src/pagination/paginationBookmarks/paginationBookmarks.resolver.ts
@@ -1,7 +1,9 @@
 import { UseGuards } from '@nestjs/common';
 import { Args, Int, Query, Resolver } from '@nestjs/graphql';
 import { GqlAuthGuard } from '@readable/auth/domain/graphql-auth.guards';
-import { PaginationCursor, PaginationOrder, PaginationOrderBy } from '@readable/common/pagination/paginationCursor';
+import { PaginationOrder, PaginationOrderBy } from '@readable/common/pagination/paginationCursor';
+import { PaginationCursorInput } from '@readable/common/pagination/paginationCursor.input';
+import { PaginationCursorScalar } from '@readable/common/pagination/paginationCursorScalar';
 import { CurrentUser } from '@readable/middleware/current-user.decorator';
 import { User } from '@readable/users/domain/models/user.model';
 import { GetPaginationBookmarksInput } from './applications/usecases/get-pagination-bookmarks/get-pagination-bookmarks.input';
@@ -25,8 +27,8 @@ export class PaginationBookmarksResolver {
     order?: PaginationOrder,
     @Args('first', { type: () => Int, defaultValue: 10 })
     first?: number,
-    @Args('after', { type: () => PaginationCursor, nullable: true })
-    after?: PaginationCursor
+    @Args('after', { type: () => PaginationCursorScalar, nullable: true })
+    after?: PaginationCursorInput
   ): Promise<PaginationBookmarkBRFOs | null> {
     const query = new GetPaginationBookmarksInput();
     if (orderBy) query.orderBy = orderBy;

--- a/apps/server/src/pagination/paginationBookmarks/paginationBookmarks.resolver.ts
+++ b/apps/server/src/pagination/paginationBookmarks/paginationBookmarks.resolver.ts
@@ -1,6 +1,7 @@
 import { UseGuards } from '@nestjs/common';
-import { Args, Query, Resolver } from '@nestjs/graphql';
+import { Args, Int, Query, Resolver } from '@nestjs/graphql';
 import { GqlAuthGuard } from '@readable/auth/domain/graphql-auth.guards';
+import { PaginationCursor, PaginationOrder, PaginationOrderBy } from '@readable/common/pagination/paginationCursor';
 import { CurrentUser } from '@readable/middleware/current-user.decorator';
 import { User } from '@readable/users/domain/models/user.model';
 import { GetPaginationBookmarksInput } from './applications/usecases/get-pagination-bookmarks/get-pagination-bookmarks.input';
@@ -18,9 +19,21 @@ export class PaginationBookmarksResolver {
   @UseGuards(GqlAuthGuard)
   async paginationBookmarks(
     @CurrentUser() requestUser: User,
-    @Args('getPaginationBookmarksInput') query: GetPaginationBookmarksInput
+    @Args('orderBy', { type: () => PaginationOrderBy, defaultValue: PaginationOrderBy.LATEST })
+    orderBy?: PaginationOrderBy,
+    @Args('order', { type: () => PaginationOrder, defaultValue: PaginationOrder.DESC })
+    order?: PaginationOrder,
+    @Args('first', { type: () => Int, defaultValue: 10 })
+    first?: number,
+    @Args('after', { type: () => PaginationCursor, nullable: true })
+    after?: PaginationCursor
   ): Promise<PaginationBookmarkBRFOs | null> {
-    console.log('TCL: PaginationBookmarksResolver -> constructor -> requestUser', requestUser);
+    const query = new GetPaginationBookmarksInput();
+    if (orderBy) query.orderBy = orderBy;
+    if (order) query.order = order;
+    if (first) query.first = first;
+    if (after) query.after = after;
+
     return this.getPaginationBookmarksUsecase.execute(query, requestUser);
   }
 }

--- a/libs/feed/data-access-pagination-bookmarks/src/lib/usePaginationBookmarks.query.generated.tsx
+++ b/libs/feed/data-access-pagination-bookmarks/src/lib/usePaginationBookmarks.query.generated.tsx
@@ -40,7 +40,7 @@ export type PaginationBookmarksQuery = (
 
 export const PaginationBookmarksDocument = gql`
     query PaginationBookmarks {
-  paginationBookmarks(getPaginationBookmarksInput: {first: 10}) {
+  paginationBookmarks(first: 10) {
     pageInfo {
       hasNextPage
       endCursor

--- a/libs/feed/data-access-pagination-bookmarks/src/lib/usePaginationBookmarks.query.tsx
+++ b/libs/feed/data-access-pagination-bookmarks/src/lib/usePaginationBookmarks.query.tsx
@@ -4,7 +4,7 @@ import { usePaginationBookmarksQuery } from './usePaginationBookmarks.query.gene
 
 const PAGINATION_BOOKMARKS = gql`
   query PaginationBookmarks {
-    paginationBookmarks(getPaginationBookmarksInput: { first: 10 }) {
+    paginationBookmarks(first: 10) {
       pageInfo {
         hasNextPage
         endCursor

--- a/libs/shared/types/src/lib/graphql-types.ts
+++ b/libs/shared/types/src/lib/graphql-types.ts
@@ -92,15 +92,6 @@ export type DeleteBookmarkWithAuthInput = {
   readonly bookmarkId: Scalars['String'];
 };
 
-export type GetPaginationBookmarksInput = {
-  readonly after?: Maybe<Scalars['PaginationCursor']>;
-  readonly first?: Maybe<Scalars['Int']>;
-  /** Pagination bookmarks order field */
-  readonly order?: Maybe<PaginationOrder>;
-  /** Pagination bookmarks orderBy field */
-  readonly orderBy?: Maybe<PaginationOrderBy>;
-};
-
 export type Mutation = {
   readonly __typename?: 'Mutation';
   readonly addBookmarkInGoogleEventsWithAuth: CommonOutput;
@@ -185,7 +176,10 @@ export type Query = {
 
 
 export type QuerypaginationBookmarksArgs = {
-  getPaginationBookmarksInput: GetPaginationBookmarksInput;
+  after?: Maybe<Scalars['PaginationCursor']>;
+  first?: Maybe<Scalars['Int']>;
+  order?: Maybe<PaginationOrder>;
+  orderBy?: Maybe<PaginationOrderBy>;
 };
 
 export type User = {


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

* Reference : https://stackoverflow.com/questions/66415243/merge-previous-data-while-scrolling-on-relay-pagination-graphql

pagination query method 의 parameter 로 `first`, `after` 받도록 parameter 변경함.

```
query	 {
  paginationBookmarks(
    first: 10,
    after: "",
  ) {
...
}
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ✨ New feature (non-breaking change which adds new functionality)
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [X] ♻️ Refactor (non-breaking change which refactors code)
- [ ] 🩹 Chore (non-breaking change which changes the small things)
- [ ] 📝 This change requires a documentation update

## Further to-do lists

<!-- If there are something to do further, please share them. -->
