### PR TITLE
✨ (server): Add tag filter in pagination query

### DIFF
--- a/apps/server/src/graphql-types.gql
+++ b/apps/server/src/graphql-types.gql
@@ -117,6 +117,20 @@ type FollowUserWithAuthOutputData {
   followingUser: User!
 }
 
+input GetPaginationUserBookmarksInput {
+  after: PaginationCursor
+  first: Int = 10
+
+  """Pagination bookmarks order field"""
+  order: PaginationOrder = DESC
+
+  """Pagination bookmarks orderBy field"""
+  orderBy: PaginationOrderBy = LATEST
+
+  """Pagination userBookmark filter: tag"""
+  tagId: String
+}
+
 type Interest {
   createdAt: DateTime!
   deletedAt: DateTime!
@@ -206,7 +220,7 @@ type Query {
   myInterests: [Interest!]!
   myUserBookmarks: [UserBookmark!]!
   paginationBookmarks(after: PaginationCursor, first: Int = 10, order: PaginationOrder = DESC, orderBy: PaginationOrderBy = LATEST): PaginationBookmarks
-  paginationUserBookmarks(after: PaginationCursor, first: Int = 10, order: PaginationOrder = DESC, orderBy: PaginationOrderBy = LATEST): PaginationUserBookmarks
+  paginationUserBookmarks(getPaginationUserBookmarksInput: GetPaginationUserBookmarksInput!): PaginationUserBookmarks
 }
 
 type Tag {

--- a/apps/server/src/pagination/pagination.module.ts
+++ b/apps/server/src/pagination/pagination.module.ts
@@ -5,6 +5,7 @@ import { Bookmark } from '@readable/bookmarks/infrastructures/typeorm/entities/b
 import { BookmarkUser } from '@readable/bookmarks/infrastructures/typeorm/entities/bookmarkUser.entity';
 import { BookmarksRepository } from '@readable/bookmarks/infrastructures/typeorm/repositories/bookmarks.repository';
 import { BookmarkUsersRepository } from '@readable/bookmarks/infrastructures/typeorm/repositories/bookmarkUsers.repository';
+import { TagsRepository } from '@readable/tags/infrastructures/typeorm/repositories/tags.repository';
 import { UserBookmarkRepository } from '@readable/user-bookmark/infrastructures/typeorm/repositories/user-bookmark.repository';
 import { GetPaginationBookmarksUsecase } from './paginationBookmarks/applications/usecases/get-pagination-bookmarks/get-pagination-bookmarks.usecase';
 import { PaginationBookmarksResolver } from './paginationBookmarks/paginationBookmarks.resolver';
@@ -20,6 +21,7 @@ import { PaginationUserBookmarksResolver } from './paginationUserBookmarks/pagin
       BookmarkUser,
       BookmarkUsersRepository,
       UserBookmarkRepository,
+      TagsRepository,
     ]),
     BookmarksModule,
   ],

--- a/apps/server/src/pagination/paginationUserBookmarks/applications/usecases/get-pagination-user-bookmarks/get-pagination-user-bookmarks.input.ts
+++ b/apps/server/src/pagination/paginationUserBookmarks/applications/usecases/get-pagination-user-bookmarks/get-pagination-user-bookmarks.input.ts
@@ -1,9 +1,13 @@
 import { Field, InputType } from '@nestjs/graphql';
 import { PaginationCommonInput } from '@readable/common/pagination/pagination.input';
 import { PaginationOrder, PaginationOrderBy } from '@readable/common/pagination/paginationCursor';
+import { Tag } from '@readable/tags/domain/models/tag.model';
 
 @InputType()
 export class GetPaginationUserBookmarksInput extends PaginationCommonInput {
+  @Field(type => String, { nullable: true, description: 'Pagination userBookmark filter: tag' })
+  tagId?: string;
+
   @Field(type => PaginationOrderBy, {
     defaultValue: PaginationOrderBy.LATEST,
     description: 'Pagination bookmarks orderBy field',

--- a/apps/server/src/pagination/paginationUserBookmarks/applications/usecases/get-pagination-user-bookmarks/get-pagination-user-bookmarks.usecase.ts
+++ b/apps/server/src/pagination/paginationUserBookmarks/applications/usecases/get-pagination-user-bookmarks/get-pagination-user-bookmarks.usecase.ts
@@ -1,15 +1,38 @@
 import { InjectRepository } from '@nestjs/typeorm';
 import { Usecase } from '@readable/common/applications/usecase';
-import { GetPaginationBookmarksInput } from '@readable/pagination/paginationBookmarks/applications/usecases/get-pagination-bookmarks/get-pagination-bookmarks.input';
+import { PaginationUserBookmarksFilter } from '@readable/pagination/paginationUserBookmarks/domain/models/paginationUserBookmarks.filter';
+import { PaginationUserBookmarks } from '@readable/pagination/paginationUserBookmarks/domain/models/paginationUserBookmarks.model';
+import { TagsRepository } from '@readable/tags/infrastructures/typeorm/repositories/tags.repository';
 import { UserBookmarkRepository } from '@readable/user-bookmark/infrastructures/typeorm/repositories/user-bookmark.repository';
 import { User } from '@readable/users/domain/models/user.model';
+import { GetPaginationUserBookmarksInput } from './get-pagination-user-bookmarks.input';
 
-export class GetPaginationUserBookmarksUsecase implements Usecase<any, any> {
+export class GetPaginationUserBookmarksUsecase
+  implements Usecase<GetPaginationUserBookmarksInput, PaginationUserBookmarks | null> {
   constructor(
+    @InjectRepository(TagsRepository) private readonly tagsRepository: TagsRepository,
     @InjectRepository(UserBookmarkRepository) private readonly userBookmarkRepository: UserBookmarkRepository
   ) {}
 
-  async execute(query: GetPaginationBookmarksInput, requestUser: User) {
-    return this.userBookmarkRepository.getPaginationUserBookmarks(query, requestUser);
+  async execute(query: GetPaginationUserBookmarksInput, requestUser: User) {
+    const filter = await this.generateFilter(query);
+    console.log('TCL: execute -> filter', filter);
+
+    return this.userBookmarkRepository.getPaginationUserBookmarks(query, filter);
+  }
+
+  private async generateFilter(query: GetPaginationUserBookmarksInput) {
+    const { tagId } = query;
+
+    const filter: PaginationUserBookmarksFilter = {};
+
+    if (tagId) {
+      // const tag = await this.tagsRepository.findOne({ where: { id: tagId } });
+      // filter.tag = tag;
+
+      filter.tagId = tagId;
+    }
+
+    return filter;
   }
 }

--- a/apps/server/src/pagination/paginationUserBookmarks/applications/usecases/get-pagination-user-bookmarks/get-pagination-user-bookmarks.usecase.ts
+++ b/apps/server/src/pagination/paginationUserBookmarks/applications/usecases/get-pagination-user-bookmarks/get-pagination-user-bookmarks.usecase.ts
@@ -16,8 +16,6 @@ export class GetPaginationUserBookmarksUsecase
 
   async execute(query: GetPaginationUserBookmarksInput, requestUser: User) {
     const filter = await this.generateFilter(query);
-    console.log('TCL: execute -> filter', filter);
-
     return this.userBookmarkRepository.getPaginationUserBookmarks(query, filter);
   }
 
@@ -27,9 +25,6 @@ export class GetPaginationUserBookmarksUsecase
     const filter: PaginationUserBookmarksFilter = {};
 
     if (tagId) {
-      // const tag = await this.tagsRepository.findOne({ where: { id: tagId } });
-      // filter.tag = tag;
-
       filter.tagId = tagId;
     }
 

--- a/apps/server/src/pagination/paginationUserBookmarks/domain/models/paginationUserBookmarks.filter.ts
+++ b/apps/server/src/pagination/paginationUserBookmarks/domain/models/paginationUserBookmarks.filter.ts
@@ -1,0 +1,6 @@
+import { Tag } from '@readable/tags/infrastructures/typeorm/entities/tags.entity';
+
+export interface PaginationUserBookmarksFilter {
+  tag?: Tag;
+  tagId?: string;
+}

--- a/apps/server/src/pagination/paginationUserBookmarks/paginationUserBookmarks.resolver.ts
+++ b/apps/server/src/pagination/paginationUserBookmarks/paginationUserBookmarks.resolver.ts
@@ -1,9 +1,6 @@
 import { UseGuards } from '@nestjs/common';
-import { Args, Int, Query, Resolver } from '@nestjs/graphql';
+import { Args, Query, Resolver } from '@nestjs/graphql';
 import { GqlAuthGuard } from '@readable/auth/domain/graphql-auth.guards';
-import { PaginationOrder, PaginationOrderBy } from '@readable/common/pagination/paginationCursor';
-import { PaginationCursorInput } from '@readable/common/pagination/paginationCursor.input';
-import { PaginationCursorScalar } from '@readable/common/pagination/paginationCursorScalar';
 import { CurrentUser } from '@readable/middleware/current-user.decorator';
 import { User } from '@readable/users/domain/models/user.model';
 import { GetPaginationUserBookmarksInput } from './applications/usecases/get-pagination-user-bookmarks/get-pagination-user-bookmarks.input';
@@ -21,21 +18,8 @@ export class PaginationUserBookmarksResolver {
   @UseGuards(GqlAuthGuard)
   async paginationUserBookmarks(
     @CurrentUser() requestUser: User,
-    @Args('orderBy', { type: () => PaginationOrderBy, defaultValue: PaginationOrderBy.LATEST })
-    orderBy?: PaginationOrderBy,
-    @Args('order', { type: () => PaginationOrder, defaultValue: PaginationOrder.DESC })
-    order?: PaginationOrder,
-    @Args('first', { type: () => Int, defaultValue: 10 })
-    first?: number,
-    @Args('after', { type: () => PaginationCursorScalar, nullable: true })
-    after?: PaginationCursorInput
+    @Args('getPaginationUserBookmarksInput') getPaginationUserBookmarksInput: GetPaginationUserBookmarksInput
   ): Promise<PaginationUserBookmarkBRFOs | null> {
-    const query = new GetPaginationUserBookmarksInput();
-    if (orderBy) query.orderBy = orderBy;
-    if (order) query.order = order;
-    if (first) query.first = first;
-    if (after) query.after = after;
-
-    return this.getPaginationUserBookmarksUsecase.execute(query, requestUser);
+    return this.getPaginationUserBookmarksUsecase.execute(getPaginationUserBookmarksInput, requestUser);
   }
 }


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change

<!-- Please delete options that are not relevant. -->

* `paginationUserBookmarks` Pagination query filter for tag: `tagId: string` should be provided.

```
query	 {
  paginationUserBookmarks(getPaginationUserBookmarksInput: {
      first: 10,
      tagId: "8f0f7b0d-9bfd-49ea-b798-d022ea11eb32"
    }) {
```

- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] ✨ New feature (non-breaking change which adds new functionality)
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ♻️ Refactor (non-breaking change which refactors code)
- [ ] 🩹 Chore (non-breaking change which changes the small things)
- [ ] 📝 This change requires a documentation update

![Xnip2021-09-16_09-16-07](https://user-images.githubusercontent.com/365500/133529405-e49dd32f-d99f-4611-9448-08d3672ed84c.jpg)

## Further to-do lists

<!-- If there are something to do further, please share them. -->
