### PR TITLE
✨ (server): Add allUserBookmarksBySearch query

### DIFF
--- a/apps/server/src/graphql-types.gql
+++ b/apps/server/src/graphql-types.gql
@@ -151,6 +151,7 @@ type PaginationUserBookmarks {
 
 type Query {
   allUrlInfosBySearch(searchByTextInAllUrlinfosInput: SearchByTextInAllUrlinfosInput!): [UrlInfo!]
+  allUserBookmarksBySearch(searchByTextInAllUserBookmarksInput: SearchByTextInAllUserBookmarksInput!): [UserBookmark!]
   me: User!
   myInterests: [Interest!]!
   myUserBookmarks: [UserBookmark!]!
@@ -164,6 +165,10 @@ type Query {
 }
 
 input SearchByTextInAllUrlinfosInput {
+  query: String!
+}
+
+input SearchByTextInAllUserBookmarksInput {
   query: String!
 }
 

--- a/apps/server/src/search/applications/usecases/search-by-text-in-all-userBookmarks/search-by-text-in-all-userBookmarks.input.ts
+++ b/apps/server/src/search/applications/usecases/search-by-text-in-all-userBookmarks/search-by-text-in-all-userBookmarks.input.ts
@@ -1,0 +1,7 @@
+import { Field, InputType } from '@nestjs/graphql';
+
+@InputType()
+export class SearchByTextInAllUserBookmarksInput {
+  @Field(type => String)
+  query: string;
+}

--- a/apps/server/src/search/applications/usecases/search-by-text-in-all-userBookmarks/search-by-text-in-all-userBookmarks.usecase.ts
+++ b/apps/server/src/search/applications/usecases/search-by-text-in-all-userBookmarks/search-by-text-in-all-userBookmarks.usecase.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Usecase } from '@readable/common/applications/usecase';
+import { SearchDomain } from '@readable/search/domain/models/search.model';
+import { SearchService } from '@readable/search/search.service';
+import { UserBookmarkRepository } from '@readable/user-bookmark/infrastructures/typeorm/repositories/user-bookmark.repository';
+import { SearchByTextInAllUserBookmarksInput } from './search-by-text-in-all-userBookmarks.input';
+
+@Injectable()
+export class SearchByTextInAllUserBookmarksUseCase implements Usecase<SearchByTextInAllUserBookmarksInput, any> {
+  constructor(
+    private readonly searchService: SearchService,
+    @InjectRepository(UserBookmarkRepository) private readonly userBookmarkRepository: UserBookmarkRepository
+  ) {}
+
+  async execute(query: SearchByTextInAllUserBookmarksInput) {
+    const { query: queryText } = query;
+
+    const {
+      data: { hits },
+    } = await this.searchService.search(SearchDomain.urlInfo.index, queryText, SearchDomain.urlInfo.properties);
+
+    if (hits.total.value === 0) return [];
+
+    const urlInfoIds = hits.hits.map(({ _id }) => _id);
+
+    return this.userBookmarkRepository.findUserBookmarksByUrlInfoIds(urlInfoIds);
+  }
+}

--- a/apps/server/src/search/search.module.ts
+++ b/apps/server/src/search/search.module.ts
@@ -4,9 +4,19 @@ import { SearchResolver } from './search.resolver';
 import { SearchByTextInAllUrlinfosUsecase } from './applications/usecases/search-by-text-in-all-urlinfos/search-by-text-in-all-urlinfos.usecase';
 import { SuggestTagUsecase } from './applications/usecases/suggest-tag/suggest-tag.usecase';
 import { SearchController } from './search.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { UserBookmarkRepository } from '@readable/user-bookmark/infrastructures/typeorm/repositories/user-bookmark.repository';
+import { SearchByTextInAllUserBookmarksUseCase } from './applications/usecases/search-by-text-in-all-userBookmarks/search-by-text-in-all-userBookmarks.usecase';
 
 @Module({
-  providers: [SearchService, SearchResolver, SearchByTextInAllUrlinfosUsecase, SuggestTagUsecase],
+  imports: [TypeOrmModule.forFeature([UserBookmarkRepository])],
+  providers: [
+    SearchService,
+    SearchResolver,
+    SearchByTextInAllUserBookmarksUseCase,
+    SearchByTextInAllUrlinfosUsecase,
+    SuggestTagUsecase,
+  ],
   exports: [SearchService],
   controllers: [SearchController],
 })

--- a/apps/server/src/search/search.resolver.ts
+++ b/apps/server/src/search/search.resolver.ts
@@ -1,21 +1,34 @@
 import { Args, Query, Resolver } from '@nestjs/graphql';
 import { Tag } from '@readable/tags/domain/models/tag.model';
 import { UrlInfo } from '@readable/url-info/domain/model/url-info.model';
+import { UserBookmark } from '@readable/user-bookmark/domain/model/user-bookmark.model';
 import { SearchByTextInAllUrlinfosInput } from './applications/usecases/search-by-text-in-all-urlinfos/search-by-text-in-all-urlinfos.input';
 import { SearchByTextInAllUrlinfosUsecase } from './applications/usecases/search-by-text-in-all-urlinfos/search-by-text-in-all-urlinfos.usecase';
+import { SearchByTextInAllUserBookmarksInput } from './applications/usecases/search-by-text-in-all-userBookmarks/search-by-text-in-all-userBookmarks.input';
+import { SearchByTextInAllUserBookmarksUseCase } from './applications/usecases/search-by-text-in-all-userBookmarks/search-by-text-in-all-userBookmarks.usecase';
 import { SuggestTagInput } from './applications/usecases/suggest-tag/suggest-tag.input';
 import { SuggestTagUsecase } from './applications/usecases/suggest-tag/suggest-tag.usecase';
-import { SearchService } from './search.service';
 
 @Resolver(of => UrlInfo)
 export class SearchResolver {
   constructor(
     private readonly suggestTagUsecase: SuggestTagUsecase,
-    private readonly searchByTextInAllUrlinfosUsecase: SearchByTextInAllUrlinfosUsecase
+    private readonly searchByTextInAllUrlinfosUsecase: SearchByTextInAllUrlinfosUsecase,
+    private readonly searchByTextInAllUserBookmarksUseCase: SearchByTextInAllUserBookmarksUseCase
   ) {}
 
   /*
    * Query (as noun)
+   */
+  @Query(returns => [UserBookmark], { nullable: true })
+  async allUserBookmarksBySearch(
+    @Args('searchByTextInAllUserBookmarksInput') query: SearchByTextInAllUserBookmarksInput
+  ) {
+    return this.searchByTextInAllUserBookmarksUseCase.execute(query);
+  }
+
+  /**
+   * @deprecated Use instead allUserBookmarksBySearch
    */
   @Query(returns => [UrlInfo], { nullable: true })
   async allUrlInfosBySearch(@Args('searchByTextInAllUrlinfosInput') query: SearchByTextInAllUrlinfosInput) {

--- a/apps/server/src/user-bookmark/infrastructures/typeorm/repositories/user-bookmark.repository.ts
+++ b/apps/server/src/user-bookmark/infrastructures/typeorm/repositories/user-bookmark.repository.ts
@@ -10,6 +10,16 @@ import { UserBookmark } from '../entities/user-bookmark.entity';
 @Injectable()
 @EntityRepository(UserBookmark)
 export class UserBookmarkRepository extends Repository<UserBookmark> {
+  async findUserBookmarksByUrlInfoIds(urlInfoIds: string[]) {
+    const queryBuilder = this.createQueryBuilder('userBookmark')
+      .innerJoinAndSelect('userBookmark.urlInfo', 'urlInfo', 'urlInfo.id IN (:...urlInfoIds)', {
+        urlInfoIds,
+      })
+      .groupBy('urlInfo.id');
+
+    return queryBuilder.orderBy('userBookmark.createdAt', 'DESC').getMany();
+  }
+
   async findOtherUserBookmarksByTags(userId: string, tags: Tag[]) {
     const queryBuilder = this.createQueryBuilder('userBookmark')
       .innerJoinAndSelect('userBookmark.tags', 'tags', 'tags.id IN (:tagIds)', { tagIds: tags.map(tag => tag.id) })


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change

<!-- Please delete options that are not relevant. -->

* 검색 결과로 기존에 `urlInfo` 주었으나 pagination 과 동일하게 `userBookmarks` 형태로 내려줌.
* 현재는 No pagination.
   -  앞으로 있어야 할 것 같은데, 한 번 이야기를 해봅시다.
* `tag` 정보를 보여야 할까 ? 고민 중

```
query AllUserBookmarksBySearch(
  $searchByTextInAllUserBookmarksInput:  SearchByTextInAllUserBookmarksInput!
 ){
  allUserBookmarksBySearch(
    searchByTextInAllUserBookmarksInput: $searchByTextInAllUserBookmarksInput
  ) {
          id
          urlHash
          urlInfo {
            id
            url
            urlHash
            title
            siteName
            imageUrl
            description
          }
          bookmarkersCount
          bookmarkers {
            id
            name
            email
            avatarUrl
          }
          readersCount
          readers {
            id
            name
            email
            avatarUrl
          }
  }
}
```

- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] ✨ New feature (non-breaking change which adds new functionality)
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ♻️ Refactor (non-breaking change which refactors code)
- [ ] 🩹 Chore (non-breaking change which changes the small things)
- [ ] 📝 This change requires a documentation update

## Further to-do lists

<!-- If there are something to do further, please share them. -->
