### PR TITLE
✨ (server): Add myReadUserBookmark filter in paginationUserBookmarks

### DIFF
--- a/apps/server/src/graphql-types.gql
+++ b/apps/server/src/graphql-types.gql
@@ -167,7 +167,7 @@ type Query {
   myUserBookmarks: [UserBookmark!]!
   myUserBookmarksGroupedByInterests: [FindMyUserBookmarksGroupedByInterestsOutput!]!
   paginationTags(after: PaginationCursor, first: Int = 10, order: PaginationOrder = DESC, orderBy: PaginationOrderBy = LATEST): PaginationTags
-  paginationUserBookmarks(after: PaginationCursor, first: Int = 10, interestId: String, myUserBookmark: Boolean, order: PaginationOrder = DESC, orderBy: PaginationOrderBy = LATEST, tagId: String, userId: String): PaginationUserBookmarks
+  paginationUserBookmarks(after: PaginationCursor, first: Int = 10, interestId: String, myReadUserBookmark: Boolean, myUserBookmark: Boolean, order: PaginationOrder = DESC, orderBy: PaginationOrderBy = LATEST, tagId: String, userId: String): PaginationUserBookmarks
   popularTags(findPopularTagsWithAuthInput: FindPopularTagsWithAuthInput!): [Tag!]
   recommendUsers: [User!]!
   tagSuggestion(suggestTagInput: SuggestTagInput!): [Tag!]

--- a/apps/server/src/pagination/pagination.service.ts
+++ b/apps/server/src/pagination/pagination.service.ts
@@ -87,7 +87,7 @@ export class PaginationService {
   }
 
   async generateUserBookmarksFilter(query: GetPaginationUserBookmarksInput) {
-    const { tagId, interestId, myUserBookmark, userId } = query;
+    const { tagId, interestId, myUserBookmark, myReadUserBookmark, userId } = query;
 
     const filter: PaginationUserBookmarksFilter = {};
 
@@ -104,6 +104,10 @@ export class PaginationService {
 
     if (myUserBookmark) {
       filter.myUserBookmark = myUserBookmark;
+    }
+
+    if (myReadUserBookmark) {
+      filter.myReadUserBookmark = myReadUserBookmark;
     }
 
     if (userId) {

--- a/apps/server/src/pagination/userBookmarks/applications/usecases/get-pagination-user-bookmarks/get-pagination-user-bookmarks.input.ts
+++ b/apps/server/src/pagination/userBookmarks/applications/usecases/get-pagination-user-bookmarks/get-pagination-user-bookmarks.input.ts
@@ -31,6 +31,9 @@ export class GetPaginationUserBookmarksInput extends PaginationCommonInput {
   @Field(type => Boolean, { nullable: true, description: 'Pagination userBookmark filter: myUserBookmark' })
   myUserBookmark?: boolean;
 
+  @Field(type => Boolean, { nullable: true, description: 'Pagination userBookmark filter: myReadUserBookmark' })
+  myReadUserBookmark?: boolean;
+
   @Field(type => String, { nullable: true, description: 'Pagination userBookmark filter: userId' })
   userId?: string;
 }

--- a/apps/server/src/pagination/userBookmarks/domain/models/paginationUserBookmarks.filter.ts
+++ b/apps/server/src/pagination/userBookmarks/domain/models/paginationUserBookmarks.filter.ts
@@ -2,5 +2,6 @@ export interface PaginationUserBookmarksFilter {
   normalizedTag?: string;
   interestId?: string;
   myUserBookmark?: boolean;
+  myReadUserBookmark?: boolean;
   userId?: string;
 }

--- a/apps/server/src/pagination/userBookmarks/paginationUserBookmarks.resolver.ts
+++ b/apps/server/src/pagination/userBookmarks/paginationUserBookmarks.resolver.ts
@@ -33,6 +33,7 @@ export class PaginationUserBookmarksResolver {
     @Args('tagId', { type: () => String, nullable: true }) tagId?: string,
     @Args('interestId', { type: () => String, nullable: true }) interestId?: string,
     @Args('myUserBookmark', { type: () => Boolean, nullable: true }) myUserBookmark?: boolean,
+    @Args('myReadUserBookmark', { type: () => Boolean, nullable: true }) myReadUserBookmark?: boolean,
     @Args('userId', { type: () => String, nullable: true }) userId?: string
   ): Promise<PaginationUserBookmarkBRFOs | null> {
     const query = new GetPaginationUserBookmarksInput();
@@ -43,6 +44,7 @@ export class PaginationUserBookmarksResolver {
     if (tagId) query.tagId = tagId;
     if (interestId) query.interestId = interestId;
     if (myUserBookmark) query.myUserBookmark = myUserBookmark;
+    if (myReadUserBookmark) query.myReadUserBookmark = myReadUserBookmark;
     if (userId) query.userId = userId;
 
     return this.getPaginationUserBookmarksUsecase.execute(query, requestUser);

--- a/apps/server/src/user-bookmark/infrastructures/typeorm/repositories/user-bookmark.repository.ts
+++ b/apps/server/src/user-bookmark/infrastructures/typeorm/repositories/user-bookmark.repository.ts
@@ -60,7 +60,7 @@ export class UserBookmarkRepository extends Repository<UserBookmark> {
     requestUser: User
   ) {
     const { first, after, order, orderBy } = query;
-    const { normalizedTag, interestId, myUserBookmark, userId } = filter;
+    const { normalizedTag, interestId, myUserBookmark, myReadUserBookmark, userId } = filter;
 
     const criteria = {
       isPrivate: false,
@@ -101,6 +101,12 @@ export class UserBookmarkRepository extends Repository<UserBookmark> {
 
     if (myUserBookmark) {
       queryBuilder.andWhere('userBookmark.userId = :userId', { userId: requestUser.id });
+    }
+
+    if (myReadUserBookmark) {
+      queryBuilder
+        .andWhere('userBookmark.userId = :userId', { userId: requestUser.id })
+        .andWhere('userBookmark.donedAt IS NOT NULL');
     }
 
     if (userId) {


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change

<!-- Please delete options that are not relevant. -->

```
{
    "first": 10,
    "after": null,
    "tagId": null,
    "interestId": null,
    "myUserBookmark": null,
    "myReadUserBookmark": true,  // !!!
    "userId": null
}

  query PaginationUserBookmarksOnFeed(
      $first: Int, 
      $after: PaginationCursor, 
      $tagId: String,
      $interestId: String,
      $myUserBookmark: Boolean,
      $myReadUserBookmark: Boolean,
      $userId: String
  ) {
    paginationUserBookmarks(
      first: $first, 
      after: $after,
      tagId: $tagId,
      interestId: $interestId,
      myUserBookmark: $myUserBookmark,
      myReadUserBookmark: $myReadUserBookmark,
      userId: $userId
    ) {
```

- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ✨ New feature (non-breaking change which adds new functionality)
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ♻️ Refactor (non-breaking change which refactors code)
- [ ] 🩹 Chore (non-breaking change which changes the small things)
- [ ] 📝 This change requires a documentation update

## Further to-do lists

<!-- If there are something to do further, please share them. -->
