### PR TITLE
✨ (server): Add limit parameter in myUserBookmarksGroupedByInterests

### DIFF
--- a/apps/server/src/graphql-types.gql
+++ b/apps/server/src/graphql-types.gql
@@ -28,6 +28,10 @@ type FindMyUserBookmarksGroupedByInterestData {
   interestId: String!
 }
 
+input FindMyUserBookmarksGroupedByInterestsInput {
+  limit: Float!
+}
+
 type FindMyUserBookmarksGroupedByInterestsOutput {
   interest: FindMyUserBookmarksGroupedByInterestData!
   userBookmarks: [UserBookmark!]!
@@ -165,7 +169,7 @@ type Query {
   me: User!
   myInterests: [Interest!]!
   myUserBookmarks: [UserBookmark!]!
-  myUserBookmarksGroupedByInterests: [FindMyUserBookmarksGroupedByInterestsOutput!]!
+  myUserBookmarksGroupedByInterests(findMyUserBookmarksGroupedByInterestsInput: FindMyUserBookmarksGroupedByInterestsInput!): [FindMyUserBookmarksGroupedByInterestsOutput!]!
   paginationTags(after: PaginationCursor, first: Int = 10, order: PaginationOrder = DESC, orderBy: PaginationOrderBy = LATEST): PaginationTags
   paginationUserBookmarks(after: PaginationCursor, first: Int = 10, interestId: String, myReadUserBookmark: Boolean, myUserBookmark: Boolean, order: PaginationOrder = DESC, orderBy: PaginationOrderBy = LATEST, tagId: String, userId: String): PaginationUserBookmarks
   popularTags(findPopularTagsWithAuthInput: FindPopularTagsWithAuthInput!): [Tag!]

--- a/apps/server/src/user-bookmark/applications/usecases/find-my-userBookmarks-grouped-by-interests/find-my-userBookmarks-grouped-by-interests.input.ts
+++ b/apps/server/src/user-bookmark/applications/usecases/find-my-userBookmarks-grouped-by-interests/find-my-userBookmarks-grouped-by-interests.input.ts
@@ -2,10 +2,10 @@ import { Field, InputType } from '@nestjs/graphql';
 
 @InputType()
 export class FindMyUserBookmarksGroupedByInterestsInput {
-  @Field(type => String)
-  userId: string;
+  @Field(type => Number)
+  limit: number;
 
-  constructor(userId: string) {
-    this.userId = userId;
+  constructor(limit: number) {
+    this.limit = limit;
   }
 }

--- a/apps/server/src/user-bookmark/applications/usecases/find-my-userBookmarks-grouped-by-interests/find-my-userBookmarks-grouped-by-interests.usecase.ts
+++ b/apps/server/src/user-bookmark/applications/usecases/find-my-userBookmarks-grouped-by-interests/find-my-userBookmarks-grouped-by-interests.usecase.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Usecase } from '@readable/common/applications/usecase';
 import { InterestsRepository } from '@readable/interests/infrastructures/typeorm/repositories/interest.repository';
 import { UserBookmarkRepository } from '@readable/user-bookmark/infrastructures/typeorm/repositories/user-bookmark.repository';
+import { User } from '@readable/users/domain/models/user.model';
 import { UsersRepository } from '@readable/users/infrastructures/typeorm/repositories/users.repository';
 import { FindMyUserBookmarksGroupedByInterestsInput } from './find-my-userBookmarks-grouped-by-interests.input';
 import {
@@ -19,12 +20,12 @@ export class FindMyUserBookmarksGroupedByInterestsUsecase
     @InjectRepository(UsersRepository) private readonly usersRepository: UsersRepository
   ) {}
 
-  async execute(query: FindMyUserBookmarksGroupedByInterestsInput) {
-    const { userId } = query;
+  async execute(query: FindMyUserBookmarksGroupedByInterestsInput, requestUser: User) {
+    const { limit } = query;
     const result: FindMyUserBookmarksGroupedByInterestsOutput[] = [];
 
     const myInterests = await this.interestsRepository.find({
-      where: { userId },
+      where: { userId: requestUser.id },
       order: {
         interest: 'ASC',
         createdAt: 'DESC',
@@ -38,10 +39,10 @@ export class FindMyUserBookmarksGroupedByInterestsUsecase
     for (const interest of myInterests) {
       const userBookmarksByInterest = await this.userBookmarkRepository.find({
         where: {
-          userId,
+          userId: requestUser.id,
           interest,
         },
-        take: 3,
+        take: limit,
         order: {
           createdAt: 'DESC',
         },

--- a/apps/server/src/user-bookmark/user-bookmark.resolver.ts
+++ b/apps/server/src/user-bookmark/user-bookmark.resolver.ts
@@ -36,10 +36,15 @@ export class UserBookmarkResolver {
 
   @Query(returns => [FindMyUserBookmarksGroupedByInterestsOutput])
   @UseGuards(GqlAuthGuard)
-  async myUserBookmarksGroupedByInterests(@CurrentUser() requestUser: User) {
-    const query = new FindMyUserBookmarksGroupedByInterestsInput(requestUser.id);
-
-    return this.findMyUserBookmarksGroupedByInterestsUsecase.execute(query);
+  async myUserBookmarksGroupedByInterests(
+    @CurrentUser() requestUser: User,
+    @Args('findMyUserBookmarksGroupedByInterestsInput')
+    findMyUserBookmarksGroupedByInterestsInput: FindMyUserBookmarksGroupedByInterestsInput
+  ) {
+    return this.findMyUserBookmarksGroupedByInterestsUsecase.execute(
+      findMyUserBookmarksGroupedByInterestsInput,
+      requestUser
+    );
   }
 
   /*


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change

<!-- Please delete options that are not relevant. -->

```
{
    "findMyUserBookmarksGroupedByInterestsInput": {
        "limit": 5
    }
}

query  MyUserBookmarksGroupedByInterests(
  $findMyUserBookmarksGroupedByInterestsInput: FindMyUserBookmarksGroupedByInterestsInput!
) {
  myUserBookmarksGroupedByInterests(
    findMyUserBookmarksGroupedByInterestsInput: $findMyUserBookmarksGroupedByInterestsInput
  ) {
    interest {
        interestId
        interest
    }
    userBookmarks {
      id
      urlHash
      isPrivate
      urlInfo {
        id
        url
        urlHash
        title
      }
    }    
  }
}
```

- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ✨ New feature (non-breaking change which adds new functionality)
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ♻️ Refactor (non-breaking change which refactors code)
- [ ] 🩹 Chore (non-breaking change which changes the small things)
- [ ] 📝 This change requires a documentation update

## Further to-do lists

<!-- If there are something to do further, please share them. -->
