### PR TITLE
✨ (server): Add getUserProfile usecase

### DIFF
--- a/apps/server/src/graphql-types.gql
+++ b/apps/server/src/graphql-types.gql
@@ -81,6 +81,10 @@ type FollowUserWithAuthOutputData {
   followingUser: User!
 }
 
+input GetUserProfileInput {
+  userId: String!
+}
+
 type Interest {
   createdAt: DateTime!
   deletedAt: DateTime!
@@ -176,6 +180,7 @@ type Query {
   popularTags(findPopularTagsWithAuthInput: FindPopularTagsWithAuthInput!): [Tag!]
   recommendUsers: [User!]!
   tagSuggestion(suggestTagInput: SuggestTagInput!): [Tag!]
+  userProfile(getUserProfileInput: GetUserProfileInput!): User!
   usersHavingManyFollowers(findUsersHavingManyFollowersWithAuthInput: FindUsersHavingManyFollowersWithAuthInput!): [User!]!
   usersHavingManyUserBookmarks(findUsersHavingManyUserBookmarksWithAuthInput: FindUsersHavingManyUserBookmarksWithAuthInput!): [User!]!
 }

--- a/apps/server/src/users/applications/usecases/get-user-profile/get-user-profile.input.ts
+++ b/apps/server/src/users/applications/usecases/get-user-profile/get-user-profile.input.ts
@@ -1,0 +1,11 @@
+import { Field, InputType } from '@nestjs/graphql';
+
+@InputType()
+export class GetUserProfileInput {
+  @Field()
+  userId: string;
+
+  constructor(userId: string) {
+    this.userId = userId;
+  }
+}

--- a/apps/server/src/users/applications/usecases/get-user-profile/get-user-profile.usecase.ts
+++ b/apps/server/src/users/applications/usecases/get-user-profile/get-user-profile.usecase.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Usecase } from '@readable/common/applications/usecase';
+import { UserNotFoundException } from '@readable/users/domain/errors/users.error';
+import { User } from '@readable/users/infrastructures/typeorm/entities/user.entity';
+import { UsersRepository } from '@readable/users/infrastructures/typeorm/repositories/users.repository';
+import { GetUserProfileInput } from './get-user-profile.input';
+
+@Injectable()
+export class GetUserProfileUseCase implements Usecase<GetUserProfileInput, User> {
+  constructor(@InjectRepository(UsersRepository) private readonly usersRepository: UsersRepository) {}
+
+  async execute(query: GetUserProfileInput) {
+    const { userId } = query;
+
+    const user = await this.usersRepository.findOne({
+      where: { id: userId },
+      relations: ['tags'],
+    });
+
+    if (!user) throw new UserNotFoundException(userId);
+
+    return user;
+  }
+}

--- a/apps/server/src/users/users.module.ts
+++ b/apps/server/src/users/users.module.ts
@@ -15,6 +15,7 @@ import { UserBookmarkRepository } from '@readable/user-bookmark/infrastructures/
 import { FindUsersHavingManyFollowersWithAuthUsecase } from './applications/usecases/find-users-having-many-followers-with-auth/find-users-having-many-followers-with-auth.usecase';
 import { FindMyUserBookmarksGroupedByInterestsUsecase } from '../user-bookmark/applications/usecases/find-my-userBookmarks-grouped-by-interests/find-my-userBookmarks-grouped-by-interests.usecase';
 import { InterestsRepository } from '@readable/interests/infrastructures/typeorm/repositories/interest.repository';
+import { GetUserProfileUseCase } from './applications/usecases/get-user-profile/get-user-profile.usecase';
 
 @Module({
   imports: [
@@ -40,6 +41,7 @@ import { InterestsRepository } from '@readable/interests/infrastructures/typeorm
     FindManyUserBookmarksHavingUsersWithAuthUsecase,
     FindUsersHavingManyFollowersWithAuthUsecase,
     FindMyUserBookmarksGroupedByInterestsUsecase,
+    GetUserProfileUseCase,
   ],
   exports: [UsersService, JwtModule, SigninUsecase],
 })

--- a/apps/server/src/users/users.resolver.ts
+++ b/apps/server/src/users/users.resolver.ts
@@ -17,11 +17,14 @@ import { FindUsersHavingManyUserBookmarksWithAuthInput } from './applications/us
 import { FindManyUserBookmarksHavingUsersWithAuthUsecase } from './applications/usecases/find-users-having-many-userBookmarks-with-auth/find-users-having-many-userBookmarks-with-auth.usecase';
 import { FindUsersHavingManyFollowersWithAuthUsecase } from './applications/usecases/find-users-having-many-followers-with-auth/find-users-having-many-followers-with-auth.usecase';
 import { FindUsersHavingManyFollowersWithAuthInput } from './applications/usecases/find-users-having-many-followers-with-auth/find-users-having-many-followers-with-auth.input';
+import { GetUserProfileUseCase } from './applications/usecases/get-user-profile/get-user-profile.usecase';
+import { GetUserProfileInput } from './applications/usecases/get-user-profile/get-user-profile.input';
 
 @Resolver(of => User)
 export class UsersResolver {
   constructor(
     private readonly usersService: UsersService,
+    private readonly getUserProfileUseCase: GetUserProfileUseCase,
     private readonly followUserWithAuthUsecase: FollowUserWithAuthUsecase,
     private readonly unfollowUserWithAuthUsecase: UnfollowUserWithAuthUsecase,
     private readonly findManyUserBookmarksHavingUsersWithAuthUsecase: FindManyUserBookmarksHavingUsersWithAuthUsecase,
@@ -36,7 +39,14 @@ export class UsersResolver {
   @Query(returns => User)
   @UseGuards(GqlAuthGuard)
   me(@CurrentUser() user: User) {
-    return this.usersService.findUserWithRelation(user);
+    const query = new GetUserProfileInput(user.id);
+    return this.getUserProfileUseCase.execute(query);
+  }
+
+  @Query(returns => User)
+  @UseGuards(GqlAuthGuard)
+  userProfile(@Args('getUserProfileInput') getUserProfileInput: GetUserProfileInput) {
+    return this.getUserProfileUseCase.execute(getUserProfileInput);
   }
 
   @Query(returns => [User])

--- a/apps/server/src/users/users.service.ts
+++ b/apps/server/src/users/users.service.ts
@@ -11,10 +11,6 @@ export class UsersService {
     @InjectRepository(UserFollowsRepository) private readonly userFollowsRepository: UserFollowsRepository
   ) {}
 
-  findUserWithRelation(user: User) {
-    return this.usersRepository.findOne({ where: { id: user.id }, relations: ['tags'] });
-  }
-
   async findOne(id: string) {
     return this.usersRepository.findOne(id);
   }


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change

<!-- Please delete options that are not relevant. -->

* `userProfile(userId: string)` usecase adeed.

#### `me` vs `userProfile` 

`me` 는 따로 input 받지 않고, logged-in information 사용함.

```
query {
    me {
        id
        name
...
    }
}
```

* `userProfile(userId: string)` 다른 유저 조회를 위하여 `userId: string`을 입력으로 받음

```
{
    "getUserProfileInput" : {
        "userId" : "9bad5b2a-e0c6-47bf-b66d-0ee0e10ad734"
    }
}

query UserProfile($getUserProfileInput: GetUserProfileInput!) {
  userProfile(getUserProfileInput: $getUserProfileInput ) {
            id
        name
...
  }
}
```

- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] ✨ New feature (non-breaking change which adds new functionality)
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ♻️ Refactor (non-breaking change which refactors code)
- [ ] 🩹 Chore (non-breaking change which changes the small things)
- [ ] 📝 This change requires a documentation update

## Further to-do lists

<!-- If there are something to do further, please share them. -->
